### PR TITLE
Fix :Remove broken HF MCP server from default CLI config

### DIFF
--- a/configs/cli_agent_config.json
+++ b/configs/cli_agent_config.json
@@ -12,10 +12,5 @@
     "auto_event_types": ["approval_required", "error", "turn_complete"],
     "destinations": {}
   },
-  "mcpServers": {
-    "hf-mcp-server": {
-      "transport": "http",
-      "url": "https://huggingface.co/mcp?login"
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
The hf-mcp-server entry causes the agent to hang on startup. Removing it so the CLI works out of the box.