### PR TITLE
fix: pass model and llm_provider to ContextWindowExceededError constructor

### DIFF
--- a/agent/core/agent_loop.py
+++ b/agent/core/agent_loop.py
@@ -873,7 +873,11 @@ async def _call_llm_streaming(
             raise
         except Exception as e:
             if _is_context_overflow_error(e):
-                raise ContextWindowExceededError(str(e)) from e
+                raise ContextWindowExceededError(
+                    message=str(e),
+                    model=llm_params.get("model", ""),
+                    llm_provider=(llm_params.get("model", "") or "").split("/")[0],
+                ) from e
             if not _healed_effort and _is_effort_config_error(e):
                 _healed_effort = True
                 llm_params = await _heal_effort_and_rebuild_params(
@@ -1030,7 +1034,11 @@ async def _call_llm_non_streaming(
             raise
         except Exception as e:
             if _is_context_overflow_error(e):
-                raise ContextWindowExceededError(str(e)) from e
+                raise ContextWindowExceededError(
+                    message=str(e),
+                    model=llm_params.get("model", ""),
+                    llm_provider=(llm_params.get("model", "") or "").split("/")[0],
+                ) from e
             if not _healed_effort and _is_effort_config_error(e):
                 _healed_effort = True
                 llm_params = await _heal_effort_and_rebuild_params(


### PR DESCRIPTION
## What

Fix a `TypeError` in `_call_llm_streaming` and `_call_llm_non_streaming` that prevents context compaction from triggering when the LLM responds with a context overflow error.

## Why

Fixes #270. When litellm raises a `BadRequestError` (or similar) indicating the prompt exceeds the model context window, the exception handlers attempt to re-raise it as `ContextWindowExceededError` but omit the required `model` and `llm_provider` positional arguments:

```
TypeError: ContextWindowExceededError.__init__() missing 2 required positional arguments: 'model' and 'llm_provider'
```

This prevents the `except ContextWindowExceededError:` handler in the main agent loop (line ~1692) from ever catching the error, so context compaction never fires. The session is permanently stuck throwing the same `TypeError` on every iteration.

## How

Both `_call_llm_streaming` (line ~876) and `_call_llm_non_streaming` (line ~1033) now pass:

- **`model`** — from `llm_params.get("model", "")`
- **`llm_provider`** — extracted as the prefix before `/` in the model string (e.g. `"openai"`, `"anthropic"`, `"bedrock"`)

These values are already available in `llm_params` at the call site.

## Testing

- The fix is a minimal change (2 call sites, +10 lines) that matches the constructor signature used everywhere else in litellm.
- The `except ContextWindowExceededError:` handler in `run_agent` at line ~1692 can now correctly catch the re-raised error and trigger context compaction.

## Checklist

- [x] Follows existing code style
- [x] No breaking changes
- [x] Documentation updated if needed
