### PR TITLE
fix(mcp): scope HF bearer token to HuggingFace endpoints only

### DIFF
--- a/agent/core/tools.py
+++ b/agent/core/tools.py
@@ -6,6 +6,7 @@ Provides ToolSpec and ToolRouter for managing both built-in and MCP tools
 import logging
 import warnings
 from dataclasses import dataclass
+from urllib.parse import urlparse
 from typing import Any, Awaitable, Callable, Optional
 
 from fastmcp import Client
@@ -119,6 +120,20 @@ class ToolSpec:
     handler: Optional[Callable[[dict[str, Any]], Awaitable[tuple[str, bool]]]] = None
 
 
+def _is_hf_endpoint(url: str | None) -> bool:
+    """True only for HuggingFace remote MCP endpoints.
+
+    Used to scope the HF bearer token to HuggingFace servers so it is never
+    forwarded to unrelated/third-party MCP servers. Matches ``huggingface.co``
+    and its subdomains via the parsed hostname (not a substring), so lookalike
+    hosts such as ``huggingface.co.evil.com`` do not match.
+    """
+    if not url:
+        return False
+    host = (urlparse(url).hostname or "").lower()
+    return host == "huggingface.co" or host.endswith(".huggingface.co")
+
+
 class ToolRouter:
     """
     Routes tool calls to appropriate handlers.
@@ -142,7 +157,13 @@ class ToolRouter:
             mcp_servers_payload = {}
             for name, server in mcp_servers.items():
                 data = server.model_dump()
-                if hf_token:
+                # Only attach the HF bearer to HuggingFace endpoints. Injecting
+                # it into every configured MCP server leaks the token to
+                # unrelated/third-party servers and makes auth-enforcing
+                # gateways (e.g. a local data-gateway) reject the request with
+                # "invalid_token" instead of falling back to their default
+                # identity.
+                if hf_token and _is_hf_endpoint(data.get("url")):
                     data.setdefault("headers", {})["Authorization"] = (
                         f"Bearer {hf_token}"
                     )


### PR DESCRIPTION
## Problem

`ToolRouter.__init__` (`agent/core/tools.py`) injects `Authorization: Bearer <hf_token>` into the headers of **every** configured MCP server:

```python
for name, server in mcp_servers.items():
    data = server.model_dump()
    if hf_token:
        data.setdefault("headers", {})["Authorization"] = f"Bearer {hf_token}"
    mcp_servers_payload[name] = data
```

Two issues:

1. **Credential leak** — the user's HF token is sent to *every* MCP server they configure, including unrelated/third-party servers that have no business seeing it.
2. **Breaks auth-enforcing servers** — a server that grants a default identity to unauthenticated localhost callers (e.g. a self-hosted data-gateway) instead receives an unrecognized `hf_...` bearer and rejects every tool call. In my setup a local gateway returned `invalid_token: bearer token not recognized` on all calls; removing the stray header let it fall back to its default localhost identity and work.

## Fix

Only attach the HF bearer when the server URL is a HuggingFace endpoint, matched on the **parsed hostname** (`huggingface.co` or a subdomain such as `router.huggingface.co`) rather than a substring — so lookalike hosts like `huggingface.co.evil.com` don't match. Stdio servers (no URL) and all non-HF remotes now receive no `Authorization` header.

```python
if hf_token and _is_hf_endpoint(data.get("url")):
    data.setdefault("headers", {})["Authorization"] = f"Bearer {hf_token}"
```

The default `hf-mcp-server` (`https://huggingface.co/mcp?login`) still receives the token unchanged.

## Verification

`_is_hf_endpoint` behavior:

| URL | Header attached |
|-----|-----------------|
| `https://huggingface.co/mcp?login` | yes |
| `https://router.huggingface.co/v1` | yes |
| `http://127.0.0.1:8001/mcp` | no |
| `https://huggingface.co.evil.com/mcp` | no |
| stdio server (no url) | no |

Confirmed end-to-end: with the default `hf-mcp-server` plus a local data-gateway MCP, tool calls to both succeed after the change (before, the data-gateway rejected every call with `invalid_token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)