### PR TITLE
Update trl example paths in tool prompts after examples/ reorg

### DIFF
--- a/agent/tools/github_find_examples.py
+++ b/agent/tools/github_find_examples.py
@@ -412,7 +412,7 @@ GITHUB_FIND_EXAMPLES_TOOL_SPEC = {
         "Sequence: github_find_examples → github_read_file (study the example) → implement based on what you found.\n\n"
         "Skip this only for: simple data queries, status checks, non-code tasks.\n\n"
         "Examples:\n"
-        "  {keyword: 'sft', repo: 'trl'} → finds examples/scripts/sft.py\n"
+        "  {keyword: 'sft', repo: 'trl'} → finds examples/sft_gemma3/sft_gemma3.py\n"
         "  {keyword: 'grpo', repo: 'trl'} → finds GRPO training examples\n"
         "  {repo: 'trl', max_results: 20} → lists all available training method examples"
     ),

--- a/agent/tools/research_tool.py
+++ b/agent/tools/research_tool.py
@@ -185,7 +185,7 @@ hf_inspect_dataset({"dataset": "org/dataset-name", "split": "train", "sample_row
 
 # 6. Now get working code for the training method
 github_find_examples({"repo": "trl", "keyword": "sft"})
-github_read_file({"repo": "huggingface/trl", "path": "examples/scripts/sft.py"})
+github_read_file({"repo": "huggingface/trl", "path": "trl/scripts/sft.py"})
 explore_hf_docs("trl")
 ```
 


### PR DESCRIPTION
huggingface/trl#6820 deletes examples/scripts/, so two tool prompt strings pointed agents at a path that will 404:

- github_find_examples.py: the usage example now shows a real post-reorg hit (examples/sft_gemma3/sft_gemma3.py)
- research_tool.py: the github_read_file example now reads trl/scripts/sft.py, the CLI script that replaced examples/scripts/sft.py

Tool logic is untouched, it searches generic examples/ and scripts/ dirs and keeps working after the reorg.
