### PR TITLE
Highlight ML Intern mode in Hugging Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 An ML intern that autonomously researches, writes, and ships good quality ML related code using the Hugging Face ecosystem — with deep access to docs, papers, datasets, and cloud compute.
 
+**👉 Try the new [ML Intern mode in Hugging Chat](https://hf.co/chat).**
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
## Summary

- highlight the new ML Intern mode in Hugging Chat near the top of the README
- link readers directly to https://hf.co/chat

## Testing

- `ruff check .`
- `ruff format --check .`
- `git diff --check`
